### PR TITLE
Fix setup-data-folder

### DIFF
--- a/src/dataHelper.js
+++ b/src/dataHelper.js
@@ -25,6 +25,8 @@ const imprintFile    = dirname + '/data/imprint.html';
 exports.checkAndCreateFiles = checkAndCreateFiles;
 exports.writeFile = writeFile;
 exports.recreateDB = recreateDB;
+exports.createEmptyLegalFile = createEmptyLegalFile;
+exports.createEmptyImprintFile = createEmptyImprintFile;
 
 function checkAndCreateFiles() {
 	if(!fs.existsSync(databaseFile)) {

--- a/src/setup-data-folder.js
+++ b/src/setup-data-folder.js
@@ -145,11 +145,11 @@ function saveAll() {
 	dataHelper.writeFile('settings', settingsFile, settingsData);
 
 	if (!fs.existsSync(legalFile)) {
-		createEmptyLegalFile()
+		dataHelper.createEmptyLegalFile()
 	}
 
 	if (!fs.existsSync(imprintFile)) {
-		createEmptyImprintFile()
+		dataHelper.createEmptyImprintFile()
 	}
 }
 


### PR DESCRIPTION
`dataHelper.js` didn't export the functions `createEmptyLegalFile()` and `createEmptyImprintFile()` which therefore couldn't be called. They were however called in `setup-data-folder.js` (which was additionally done wrong) leading to an error.

This fixes it.