### PR TITLE
Add nixos-shell configuration

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -1,0 +1,5 @@
+{ config, pkgs, ... }:
+
+{
+    environment.systemPackages = with pkgs; [ nodejs ];
+}


### PR DESCRIPTION
`nixos-shell` is a tool for NixOS that

* launches a leightweight NixOS container,
* mounts the current directory into its `/src` and
* connects to it via SSH.

This adds a `nixos-shell` configuration specifying that `nodejs` shall be available in the container. One can then install the drinklist in the container by following the usual instructions.

NOTE: This of course isn't meant for production but as a tool for *testing* the drinklist.

TODO: If possible, add a hook that installs the drinklist in the container automatically.

TODO: Document this possibility in `README.md`.